### PR TITLE
[E-Document Core] - Show attachments for E-Document and E-Documents page

### DIFF
--- a/Apps/W1/EDocument/app/src/Document/EDocument.Page.al
+++ b/Apps/W1/EDocument/app/src/Document/EDocument.Page.al
@@ -6,6 +6,7 @@ namespace Microsoft.eServices.EDocument;
 
 using System.Telemetry;
 using System.Utilities;
+using Microsoft.Foundation.Attachment;
 using Microsoft.eServices.EDocument.Integration.Send;
 using Microsoft.eServices.EDocument.Integration.Receive;
 using Microsoft.Bank.Reconciliation;
@@ -184,6 +185,15 @@ page 6121 "E-Document"
                 ObsoleteState = Pending;
             }
 #endif
+        }
+        area(FactBoxes)
+        {
+            part(DocumentAttachment; "Doc. Attachment List Factbox")
+            {
+                Caption = 'Documents';
+                UpdatePropagation = Both;
+                SubPageLink = "E-Document Entry No." = field("Entry No"), "E-Document Attachment" = const(true);
+            }
         }
     }
     actions

--- a/Apps/W1/EDocument/app/src/Document/EDocument.Page.al
+++ b/Apps/W1/EDocument/app/src/Document/EDocument.Page.al
@@ -186,13 +186,25 @@ page 6121 "E-Document"
             }
 #endif
         }
-        area(FactBoxes)
+        area(factboxes)
         {
-            part(DocumentAttachment; "Doc. Attachment List Factbox")
+#if not CLEAN25
+            part("Attached Documents"; "Document Attachment Factbox")
+            {
+                ObsoleteTag = '25.0';
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The "Document Attachment FactBox" has been replaced by "Doc. Attachment List Factbox", which supports multiple files upload.';
+                ApplicationArea = All;
+                Caption = 'Attachments';
+                SubPageLink = "E-Document Entry No." = field("Entry No"), "E-Document Attachment" = const(true);
+            }
+#endif
+            part("Attached Documents List"; "Doc. Attachment List Factbox")
             {
                 Caption = 'Documents';
                 UpdatePropagation = Both;
-                SubPageLink = "E-Document Entry No." = field("Entry No"), "E-Document Attachment" = const(true);
+                SubPageLink = "E-Document Entry No." = field("Entry No"),
+                              "E-Document Attachment" = const(true);
             }
         }
     }

--- a/Apps/W1/EDocument/app/src/Document/EDocuments.Page.al
+++ b/Apps/W1/EDocument/app/src/Document/EDocuments.Page.al
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.eServices.EDocument;
+using Microsoft.Foundation.Attachment;
 
 page 6122 "E-Documents"
 {
@@ -53,6 +54,15 @@ page 6122 "E-Documents"
                 {
                     ToolTip = 'Specifies the status of the electronic document.';
                 }
+            }
+        }
+        area(FactBoxes)
+        {
+            part(DocumentListFactBox; "Doc. Attachment List Factbox")
+            {
+                Caption = 'Documents';
+                UpdatePropagation = Both;
+                SubPageLink = "E-Document Entry No." = field("Entry No"), "E-Document Attachment" = const(true);
             }
         }
     }

--- a/Apps/W1/EDocument/app/src/Document/EDocuments.Page.al
+++ b/Apps/W1/EDocument/app/src/Document/EDocuments.Page.al
@@ -56,13 +56,26 @@ page 6122 "E-Documents"
                 }
             }
         }
-        area(FactBoxes)
+        area(factboxes)
         {
+#if not CLEAN25
+            part("Attached Documents"; "Document Attachment Factbox")
+            {
+                ObsoleteTag = '25.0';
+                ObsoleteState = Pending;
+                ObsoleteReason = 'The "Document Attachment FactBox" has been replaced by "Doc. Attachment List Factbox", which supports multiple files upload.';
+                ApplicationArea = All;
+                Caption = 'Attachments';
+                SubPageLink = "E-Document Entry No." = field("Entry No"),
+                              "E-Document Attachment" = const(true);
+            }
+#endif
             part(DocumentListFactBox; "Doc. Attachment List Factbox")
             {
                 Caption = 'Documents';
                 UpdatePropagation = Both;
-                SubPageLink = "E-Document Entry No." = field("Entry No"), "E-Document Attachment" = const(true);
+                SubPageLink = "E-Document Entry No." = field("Entry No"),
+                              "E-Document Attachment" = const(true);
             }
         }
     }


### PR DESCRIPTION
### Show attachments on E-Document and E-Documents page

This modification adds document attachment factboxes to E-Document and E-Documents pages so user can see the attachments for incoming documents, so user can see attachment even if the E-Document is not mapped to any existing document in the system.
